### PR TITLE
Update readme for the way to start postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,33 @@
 # react-native-sample-backend
+
 the backend of react-native-sample
 
 # instalation
 
-    rake db:create && rake db:migrate && rake db:seeed
-    
+## terminal 1
+
+    postgres -D /usr/local/var/postgres -p 5432
+
+## terminal 2
+
+    rake db:create && rake db:migrate && rake db:seed
+
 # reset installation
 
+## terminal 1
+
+    postgres -D /usr/local/var/postgres -p 5432
+
+## terminal 2
+
     rake db:reset
-    
+
 # run server
 
-    rails s
+## terminal 1
+
+    postgres -D /usr/local/var/postgres -p 5432
+
+## terminal 2
+
+    rails s -p 3000


### PR DESCRIPTION
**Description**

1. Update README.md to show how to start `postgres` before running `rake` commands.
2. Fix spelling error: `db:seeed` -> `db:seed`